### PR TITLE
Set cnonce if QOP is specified

### DIFF
--- a/digest.go
+++ b/digest.go
@@ -90,12 +90,9 @@ type challenge struct {
 
 func nonce() string {
 	buf := make([]byte, 12)
-	for i := 0; i < len(buf); {
-		n, err := rand.Read(buf[i:])
-		if err != nil {
-			panic("rand.Read() failed")
-		}
-		i += n
+	_, err := io.ReadFull(rand.Reader, buf)
+	if err != nil {
+		panic("crypto/rand read failed")
 	}
 	return base64.StdEncoding.EncodeToString(buf)
 }

--- a/digest.go
+++ b/digest.go
@@ -182,7 +182,7 @@ func (c *credentials) authorize() (string, error) {
 	if c.MessageQop != "auth" && c.MessageQop != "" {
 		return "", ErrAlgNotImplemented
 	}
-	resp, err := c.resp()
+	resp, err := c.resp("")
 	if err != nil {
 		return "", ErrAlgNotImplemented
 	}

--- a/digest.go
+++ b/digest.go
@@ -92,7 +92,7 @@ func nonce() string {
 	buf := make([]byte, 12)
 	_, err := io.ReadFull(rand.Reader, buf)
 	if err != nil {
-		panic("crypto/rand read failed")
+		return ""
 	}
 	return base64.StdEncoding.EncodeToString(buf)
 }


### PR DESCRIPTION
Noticed the `cNonce` was set in the `resp` call - since `resp` is always called with no `cnonce`, we can unconditionally set it if QOP is specified.